### PR TITLE
Refactor include file handling and naming

### DIFF
--- a/include/lacc.h
+++ b/include/lacc.h
@@ -374,8 +374,8 @@ void init_global_variables();
 
 // file.c
 typedef enum { SEEK_SET, SEEK_CUR, SEEK_END } SeekWhence;
-char *read_file();
-char *find_file_includes(char *name);
+char *read_file(char *path);
+char *read_include_file(char *name);
 
 //
 // Extensions
@@ -395,6 +395,7 @@ extern void warning_at(Location *loc, char *fmt, ...);
 // stdio.h
 extern int printf(char *fmt, ...);
 extern int sprintf(char *fmt, ...);
+extern int snprintf();
 typedef struct _IO_FILE FILE;
 extern FILE *fopen(const char *filename, const char *mode);
 extern int fprintf();


### PR DESCRIPTION
## Summary
- Rename `find_file_includes` to `read_include_file` and simplify path construction with `snprintf`
- Avoid global `fp` shadowing and clarify variable naming
- Improve include directive handling with clearer `already_included` flag
- Add Japanese explanatory comments to declarator parsing helpers
- Expand inline comments inside helper functions for file reading and include directives

## Testing
- `make unittest`
- `make warntest`
- `make errortest`


------
https://chatgpt.com/codex/tasks/task_e_68a1f4dc71348323a5e7e8eb851df8bc