### PR TITLE
Optimize parser allocations and simplify string literal error handling

### DIFF
--- a/include/lacc.h
+++ b/include/lacc.h
@@ -271,7 +271,8 @@ Function *find_fn(Token *tok);
 
 // parse.c
 void error_duplicate_name(Token *tok, const char *type);
-void *safe_realloc_array(void *ptr, int element_size, int new_size);
+void *safe_realloc_array(void *ptr, int elem_size, int need, int *cap);
+
 void program();
 int peek(char *op);
 int consume(char *op);

--- a/include/lacc.h
+++ b/include/lacc.h
@@ -238,6 +238,7 @@ struct Node {
   int endline;
   int *cases;      // kindがND_SWITCHの場合のみ使う
   int case_cnt;    // kindがND_SWITCHの場合のみ使う
+  int case_cap;    // capacity of cases array
   int has_default; // kindがND_SWITCHの場合のみ使う
   Node *cond;      // kindがND_IF, ND_WHILE, ND_FORの場合のみ使う
   Node *then;      // kindがND_IFの場合のみ使う

--- a/src/lexer/tokenize.c
+++ b/src/lexer/tokenize.c
@@ -105,14 +105,7 @@ char *parse_string_literal(char *p) {
                  "unsupported escape sequence \"\\v\" in string literal. Use '\\012' for vertical tab.");
         break;
       default:
-        if (len + 2 >= cap) {
-          do {
-            cap *= 2;
-          } while (len + 2 >= cap);
-          buf = realloc(buf, cap);
-          if (!buf)
-            error("memory allocation failed");
-        }
+        buf = safe_realloc_array(buf, sizeof(char), len + 2, &cap);
         buf[len++] = *p++;
         buf[len++] = *p++;
         i++;
@@ -120,26 +113,12 @@ char *parse_string_literal(char *p) {
       }
       break;
     default:
-      if (len + 1 >= cap) {
-        do {
-          cap *= 2;
-        } while (len + 1 >= cap);
-        buf = realloc(buf, cap);
-        if (!buf)
-          error("memory allocation failed");
-      }
+      buf = safe_realloc_array(buf, sizeof(char), len + 1, &cap);
       buf[len++] = *p++;
       i++;
     }
   }
-  if (len + 1 >= cap) {
-    do {
-      cap *= 2;
-    } while (len + 1 >= cap);
-    buf = realloc(buf, cap);
-    if (!buf)
-      error("memory allocation failed");
-  }
+  buf = safe_realloc_array(buf, sizeof(char), len + 1, &cap);
   buf[len] = '\0';
   i++;
   if (token && token->kind == TK_STRING) {

--- a/src/parser/decl.c
+++ b/src/parser/decl.c
@@ -262,15 +262,12 @@ Node *vardec_and_funcdef_stmt(int is_static, int is_extern) {
   }
 
   node = new_node(ND_BLOCK);
-  int cap = 8;
-  node->body = safe_realloc_array(NULL, sizeof(Node *), cap);
+  int cap = 16;
   int i = 0;
+  node->body = malloc(sizeof(Node *) * cap);
 
   for (;;) {
-    if (i + 1 >= cap) {
-      cap *= 2;
-      node->body = safe_realloc_array(node->body, sizeof(Node *), cap);
-    }
+    node->body = safe_realloc_array(node->body, sizeof(Node *), i + 1, &cap);
     if (is_extern) {
       node->body[i++] = extern_variable_declaration(tok, type);
     } else if (current_fn) {
@@ -283,6 +280,7 @@ Node *vardec_and_funcdef_stmt(int is_static, int is_extern) {
     type = parse_declarator(base_type, &tok, "variable declaration");
   }
 
+  node->body = safe_realloc_array(node->body, sizeof(Node *), i + 1, &cap);
   node->body[i] = new_node(ND_NONE);
   expect(";", "after line", "variable declaration");
   node->endline = TRUE;

--- a/src/parser/decl.c
+++ b/src/parser/decl.c
@@ -262,11 +262,15 @@ Node *vardec_and_funcdef_stmt(int is_static, int is_extern) {
   }
 
   node = new_node(ND_BLOCK);
-  node->body = NULL;
+  int cap = 8;
+  node->body = safe_realloc_array(NULL, sizeof(Node *), cap);
   int i = 0;
 
   for (;;) {
-    node->body = safe_realloc_array(node->body, sizeof(Node *), i + 1);
+    if (i + 1 >= cap) {
+      cap *= 2;
+      node->body = safe_realloc_array(node->body, sizeof(Node *), cap);
+    }
     if (is_extern) {
       node->body[i++] = extern_variable_declaration(tok, type);
     } else if (current_fn) {
@@ -279,7 +283,6 @@ Node *vardec_and_funcdef_stmt(int is_static, int is_extern) {
     type = parse_declarator(base_type, &tok, "variable declaration");
   }
 
-  node->body = safe_realloc_array(node->body, sizeof(Node *), i + 1);
   node->body[i] = new_node(ND_NONE);
   expect(";", "after line", "variable declaration");
   node->endline = TRUE;

--- a/src/parser/parse.c
+++ b/src/parser/parse.c
@@ -87,12 +87,15 @@ void *safe_realloc_array(void *ptr, int element_size, int new_size) {
 
 void program() {
   int i = 0;
-  code = NULL;
+  int cap = 16;
+  code = safe_realloc_array(NULL, sizeof(Node *), cap);
   while (token->kind != TK_EOF) {
-    code = safe_realloc_array(code, sizeof(Node *), i + 1);
+    if (i + 1 >= cap) {
+      cap *= 2;
+      code = safe_realloc_array(code, sizeof(Node *), cap);
+    }
     code[i++] = stmt();
   }
-  code = safe_realloc_array(code, sizeof(Node *), i + 1);
   code[i] = new_node(ND_NONE);
 }
 
@@ -102,12 +105,16 @@ Array *array_literal(Type *type) {
   Array *array = malloc(sizeof(Array));
   array->id = array_cnt++;
   array->byte = get_sizeof(org_type);
-  array->val = NULL;
+  int cap = 8;
+  array->val = safe_realloc_array(NULL, sizeof(int), cap);
   array->next = arrays;
   arrays = array;
   int i = 0;
   do {
-    array->val = safe_realloc_array(array->val, sizeof(int), i + 1);
+    if (i >= cap) {
+      cap *= 2;
+      array->val = safe_realloc_array(array->val, sizeof(int), cap);
+    }
     array->val[i++] = expect_number("array_literal");
   } while (consume(","));
   array->len = i;

--- a/src/parser/parse.c
+++ b/src/parser/parse.c
@@ -97,7 +97,7 @@ void program() {
     code = safe_realloc_array(code, sizeof(Node *), i + 1, &cap);
     code[i++] = stmt();
   }
-  code = safe_realloc_array(NULL, sizeof(Node *), i + 1, &cap);
+  code = safe_realloc_array(code, sizeof(Node *), i + 1, &cap);
   code[i] = new_node(ND_NONE);
 }
 

--- a/src/parser/stmt.c
+++ b/src/parser/stmt.c
@@ -29,16 +29,14 @@ Node *block_stmt() {
   TypeTag *type_tags_prev = type_tags;
   int block_id_prev = block_id;
   block_id = block_cnt++;
-  int cap = 8;
-  node->body = safe_realloc_array(NULL, sizeof(Node *), cap);
+  int cap = 16;
+  node->body = malloc(sizeof(Node *) * cap);
   int i = 0;
   while (!consume("}")) {
-    if (i + 1 >= cap) {
-      cap *= 2;
-      node->body = safe_realloc_array(node->body, sizeof(Node *), cap);
-    }
+    node->body = safe_realloc_array(node->body, sizeof(Node *), i + 1, &cap);
     node->body[i++] = stmt();
   }
+  node->body = safe_realloc_array(node->body, sizeof(Node *), i + 1, &cap);
   node->body[i] = new_node(ND_NONE);
   block_id = block_id_prev;
   locals = locals_prev;
@@ -236,8 +234,8 @@ Node *switch_stmt() {
   node->id = label_cnt++;
   node->cond = expr();
   node->cond->endline = FALSE;
-  int cap = 8;
-  node->cases = safe_realloc_array(NULL, sizeof(int), cap);
+  int cap = 16;
+  node->cases = malloc(sizeof(int) * cap);
   node->case_cap = cap;
   node->case_cnt = 0;
   node->has_default = FALSE;
@@ -266,10 +264,8 @@ Node *case_stmt() {
       error_at(token->loc, "duplicate case value [in case statement]");
     }
   }
-  if (current_switch->case_cnt >= current_switch->case_cap) {
-    current_switch->case_cap *= 2;
-    current_switch->cases = safe_realloc_array(current_switch->cases, sizeof(int), current_switch->case_cap);
-  }
+  current_switch->cases =
+      safe_realloc_array(current_switch->cases, sizeof(int), current_switch->case_cnt + 1, &current_switch->case_cap);
   current_switch->cases[current_switch->case_cnt++] = node->val;
   expect(":", "after case value", "case");
   node->endline = TRUE;

--- a/src/types/symbol.c
+++ b/src/types/symbol.c
@@ -19,6 +19,10 @@ Node *new_node(NodeKind kind) {
   node->kind = kind;
   node->endline = FALSE;
   node->val = 0;
+  node->cases = NULL;
+  node->case_cnt = 0;
+  node->case_cap = 0;
+  node->has_default = FALSE;
   return node;
 }
 


### PR DESCRIPTION
## Summary
- Drop redundant frees on string literal errors
- Reduce repeated realloc calls by growing parser arrays exponentially and tracking switch-case capacity
- Initialize nodes with case array metadata

## Testing
- `make unittest`
- `make warntest`
- `make errortest` *(includes an intentional segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_68a3541bb1d08323b988388475462fd5