### PR TITLE
Free tokens and code after compilation

### DIFF
--- a/include/lacc.h
+++ b/include/lacc.h
@@ -386,6 +386,11 @@ typedef enum { SEEK_SET, SEEK_CUR, SEEK_END } SeekWhence;
 char *read_file(char *path);
 char *read_include_file(char *name);
 
+// memory.c
+void free_all_tokens();
+void free_node(Node *node);
+void free_all_nodes();
+
 //
 // Extensions
 //
@@ -430,4 +435,5 @@ extern char *strchr();
 // stdlib.h
 extern void *malloc();
 extern void *realloc();
+extern void *calloc();
 extern void free();

--- a/src/codegen/text_section.c
+++ b/src/codegen/text_section.c
@@ -606,7 +606,7 @@ void gen(Node *node) {
 
 void gen_text_section() {
   write_file("  .text\n");
-  for (int i = 0; code[i]->kind != ND_NONE; i++) {
+  for (int i = 0; code[i]->kind != ND_NONE; i++)
     gen(code[i]);
-  }
+  free_all_nodes();
 }

--- a/src/main.c
+++ b/src/main.c
@@ -90,6 +90,8 @@ int main(int argc, char **argv) {
 
   program();
 
+  free_all_tokens();
+
   generate_assembly();
 
   fclose(fp);

--- a/src/types/symbol.c
+++ b/src/types/symbol.c
@@ -17,12 +17,27 @@ extern void *NULL;
 Node *new_node(NodeKind kind) {
   Node *node = malloc(sizeof(Node));
   node->kind = kind;
-  node->endline = FALSE;
+  node->lhs = NULL;
+  node->rhs = NULL;
   node->val = 0;
+  node->id = 0;
+  node->endline = FALSE;
   node->cases = NULL;
   node->case_cnt = 0;
   node->case_cap = 0;
   node->has_default = FALSE;
+  node->cond = NULL;
+  node->then = NULL;
+  node->els = NULL;
+  node->init = NULL;
+  node->step = NULL;
+  node->body = NULL;
+  for (int i = 0; i < 6; i++)
+    node->args[i] = NULL;
+  node->fn = NULL;
+  node->var = NULL;
+  node->type = NULL;
+  node->label = NULL;
   return node;
 }
 

--- a/src/utils/memory.c
+++ b/src/utils/memory.c
@@ -1,0 +1,82 @@
+#include "lacc.h"
+
+extern Token *token_head;
+extern Token *token;
+extern Node **code;
+extern void *NULL;
+
+void free_all_tokens() {
+  Token *cur = token_head;
+  while (cur) {
+    Token *next = cur->next;
+    if (cur->loc)
+      free(cur->loc);
+    free(cur);
+    cur = next;
+  }
+  token_head = NULL;
+  token = NULL;
+}
+
+void free_node(Node *node) {
+  if (!node)
+    return;
+  if (node->kind == ND_NONE) {
+    free(node);
+    return;
+  }
+
+  switch (node->kind) {
+  case ND_ASSIGN:
+  case ND_POSTINC:
+    if (node->rhs)
+      free_node(node->rhs);
+    break;
+  default:
+    if (node->lhs)
+      free_node(node->lhs);
+    if (node->rhs)
+      free_node(node->rhs);
+    break;
+  }
+  if (node->cond)
+    free_node(node->cond);
+  if (node->then)
+    free_node(node->then);
+  if (node->els)
+    free_node(node->els);
+  if (node->init)
+    free_node(node->init);
+  if (node->step)
+    free_node(node->step);
+  if (node->body) {
+    int i = 0;
+    while (node->body[i] && node->body[i]->kind != ND_NONE) {
+      free_node(node->body[i]);
+      i++;
+    }
+    if (node->body[i])
+      free_node(node->body[i]);
+    free(node->body);
+  }
+  for (int i = 0; i < 6; i++)
+    if (node->args[i])
+      free_node(node->args[i]);
+  if (node->cases)
+    free(node->cases);
+  free(node);
+}
+
+void free_all_nodes() {
+  if (!code)
+    return;
+  int i = 0;
+  while (code[i] && code[i]->kind != ND_NONE) {
+    free_node(code[i]);
+    i++;
+  }
+  if (code[i])
+    free_node(code[i]);
+  free(code);
+  code = NULL;
+}


### PR DESCRIPTION
## Summary
- rename token cleanup routine to `free_all_tokens` and provide `free_all_nodes` for AST cleanup
- free generated nodes in one batch after emitting the text section
- construct AST nodes with `malloc` and explicit initialization

## Testing
- `make unittest`


------
https://chatgpt.com/codex/tasks/task_e_68a4b55a4880832382c585cac21c2ece