### PR TITLE
Handle missing source files gracefully

### DIFF
--- a/include/lacc.h
+++ b/include/lacc.h
@@ -129,6 +129,12 @@ struct Type {
   int is_variadic;       // 可変長引数かどうか
 };
 
+typedef struct TypeList TypeList;
+struct TypeList {
+  Type *type;
+  TypeList *next;
+};
+
 // Label
 typedef struct Label Label;
 struct Label {
@@ -390,6 +396,16 @@ char *read_include_file(char *name);
 void free_all_tokens();
 void free_node(Node *node);
 void free_all_nodes();
+void free_all_functions();
+void free_all_lvars();
+void free_all_objects();
+void free_all_type_tags();
+void free_all_strings();
+void free_all_filenames();
+void free_all_arrays();
+void free_all_include_paths();
+void free_all_types();
+void register_type(Type *type);
 
 //
 // Extensions

--- a/src/main.c
+++ b/src/main.c
@@ -11,6 +11,16 @@ extern char *input_file;
 extern char *output_file;
 extern IncludePath *include_paths;
 extern FILE *fp;
+extern Function *functions;
+extern LVar *globals;
+extern LVar *statics;
+extern LVar *locals;
+extern Object *structs;
+extern Object *unions;
+extern Object *enums;
+extern TypeTag *type_tags;
+extern String *strings;
+extern Array *arrays;
 extern const int TRUE;
 extern const int FALSE;
 extern void *NULL;
@@ -18,7 +28,8 @@ extern void *NULL;
 int main(int argc, char **argv) {
   init_global_variables();
   input_file = NULL;
-  char *output_file_tmp = NULL;
+  output_file = NULL;
+  int output_file_specified = FALSE;
 
   if (argc < 2) {
     error("invalid number of arguments.");
@@ -34,11 +45,20 @@ int main(int argc, char **argv) {
     } else if (!strncmp(argv[i], "-w", 2)) {
       show_warning = FALSE;
     } else if (!strncmp(argv[i], "-o", 2) && i + 1 < argc) {
-      output_file_tmp = argv[++i];
-      if (output_file_tmp[0] == '-') {
+      if (output_file_specified) {
+        error("multiple output files specified.");
+      }
+      if (output_file) {
+        free(output_file);
+      }
+      output_file_specified = TRUE;
+      char *out = argv[++i];
+      if (out[0] == '-') {
         error("output file cannot start with '-'.");
       }
-      output_file = output_file_tmp;
+      int out_len = strlen(out);
+      output_file = malloc(out_len + 1);
+      strncpy(output_file, out, out_len + 1);
     } else if (argv[i][0] == '-') {
       error("unknown option: %s", argv[i]);
     } else {
@@ -61,10 +81,12 @@ int main(int argc, char **argv) {
           break;
         }
       }
-      output_file_tmp = malloc(length - start + 1);
-      strncpy(output_file_tmp, input_file + start, length - start);
-      output_file_tmp[length - start - 1] = 's';
-      output_file_tmp[length - start] = '\0';
+      if (!output_file_specified) {
+        output_file = malloc(length - start + 1);
+        strncpy(output_file, input_file + start, length - start);
+        output_file[length - start - 1] = 's';
+        output_file[length - start] = '\0';
+      }
     }
   }
 
@@ -74,15 +96,15 @@ int main(int argc, char **argv) {
     error("no source file specified.");
   }
 
-  if (!output_file) {
-    output_file = output_file_tmp;
-  }
   fp = fopen(output_file, "w");
   if (!fp) {
     error("failed to open output file: %s", output_file);
   }
 
   user_input = read_file(input_file);
+  if (!user_input) {
+    error("failed to read source file: %s", input_file);
+  }
 
   tokenize();
   new_token(TK_EOF, NULL, NULL, 0);
@@ -93,8 +115,19 @@ int main(int argc, char **argv) {
   free_all_tokens();
 
   generate_assembly();
+  free_all_functions();
+  free_all_lvars();
+  free_all_objects();
+  free_all_type_tags();
+  free_all_strings();
+  free_all_arrays();
+  free_all_include_paths();
+  free_all_filenames();
+  free(user_input);
+  free_all_types();
 
   fclose(fp);
+  free(output_file);
 
   if (show_warning) {
     if (warning_cnt == 1) {

--- a/src/types/type.c
+++ b/src/types/type.c
@@ -10,6 +10,7 @@ extern void *NULL;
 
 Type *new_type(TypeKind ty) {
   Type *type = malloc(sizeof(Type));
+  register_type(type);
   type->ty = ty;
   type->ptr_to = NULL;
   type->array_size = 0;

--- a/src/utils/memory.c
+++ b/src/utils/memory.c
@@ -2,8 +2,20 @@
 
 extern Token *token_head;
 extern Token *token;
-extern Node **code;
 extern void *NULL;
+extern Function *functions;
+extern LVar *locals;
+extern LVar *globals;
+extern LVar *statics;
+extern Object *structs;
+extern Object *unions;
+extern Object *enums;
+extern TypeTag *type_tags;
+extern String *strings;
+extern String *filenames;
+extern Array *arrays;
+extern IncludePath *include_paths;
+extern Node **code;
 
 void free_all_tokens() {
   Token *cur = token_head;
@@ -26,6 +38,11 @@ void free_node(Node *node) {
     return;
   }
 
+  // Compound assignments and post-increment expressions reuse the left
+  // operand within the right-hand subtree. Freeing both sides would therefore
+  // traverse shared nodes twice and lead to double free. Only descend into the
+  // right-hand side for such nodes; the left-hand side will be freed as part of
+  // that subtree.
   switch (node->kind) {
   case ND_ASSIGN:
   case ND_POSTINC:
@@ -79,4 +96,137 @@ void free_all_nodes() {
     free_node(code[i]);
   free(code);
   code = NULL;
+}
+
+static TypeList *type_list = 0;
+
+void register_type(Type *type) {
+  TypeList *tl = malloc(sizeof(TypeList));
+  tl->type = type;
+  tl->next = type_list;
+  type_list = tl;
+}
+
+void free_all_types() {
+  TypeList *tl = type_list;
+  while (tl) {
+    TypeList *next = tl->next;
+    free(tl->type);
+    free(tl);
+    tl = next;
+  }
+  type_list = NULL;
+}
+
+static void free_labels(Label *label) {
+  while (label) {
+    Label *next = label->next;
+    free(label);
+    label = next;
+  }
+}
+
+static void free_functions(Function *fn) {
+  while (fn) {
+    Function *next = fn->next;
+    free_labels(fn->labels);
+    free(fn);
+    fn = next;
+  }
+}
+
+static void free_lvars(LVar *var) {
+  while (var) {
+    LVar *next = var->next;
+    free(var);
+    var = next;
+  }
+}
+
+static void free_objects_list(Object *obj) {
+  while (obj) {
+    Object *next = obj->next;
+    if (obj->var)
+      free_lvars(obj->var);
+    free(obj);
+    obj = next;
+  }
+}
+
+static void free_type_tags_list(TypeTag *tag) {
+  while (tag) {
+    TypeTag *next = tag->next;
+    free(tag);
+    tag = next;
+  }
+}
+
+static void free_strings_list(String *str) {
+  while (str) {
+    String *next = str->next;
+    free(str);
+    str = next;
+  }
+}
+
+static void free_arrays_list(Array *arr) {
+  while (arr) {
+    Array *next = arr->next;
+    if (arr->val)
+      free(arr->val);
+    free(arr);
+    arr = next;
+  }
+}
+
+static void free_include_paths_list(IncludePath *path) {
+  while (path) {
+    IncludePath *next = path->next;
+    free(path);
+    path = next;
+  }
+}
+
+void free_all_functions() {
+  free_functions(functions);
+  functions = NULL;
+}
+
+void free_all_lvars() {
+  free_lvars(locals);
+  free_lvars(globals);
+  free_lvars(statics);
+  locals = globals = statics = NULL;
+}
+
+void free_all_objects() {
+  free_objects_list(structs);
+  free_objects_list(unions);
+  free_objects_list(enums);
+  structs = unions = enums = NULL;
+}
+
+void free_all_type_tags() {
+  free_type_tags_list(type_tags);
+  type_tags = NULL;
+}
+
+void free_all_strings() {
+  free_strings_list(strings);
+  strings = NULL;
+}
+
+void free_all_filenames() {
+  free_strings_list(filenames);
+  filenames = NULL;
+}
+
+void free_all_arrays() {
+  free_arrays_list(arrays);
+  arrays = NULL;
+}
+
+void free_all_include_paths() {
+  free_include_paths_list(include_paths);
+  include_paths = NULL;
 }


### PR DESCRIPTION
## Summary
- guard against missing source files by checking the result of `read_file`
- expose cleanup helpers and free compiler structures after code generation
- free the entire AST in one pass after code emission and document why assignments and post-inc nodes only release their right-hand side

## Testing
- `make unittest`
- `make warntest`
- `make errortest`


------
https://chatgpt.com/codex/tasks/task_e_68a4bfa9eb508323a5b7a52ce10f3e4c