### PR TITLE
Fix sanitizer memory leak

### DIFF
--- a/include/lacc.h
+++ b/include/lacc.h
@@ -431,6 +431,7 @@ void free_all_lvars();
 void register_type(Type *type);
 void free_all_types();
 void register_char_ptr(char *str);
+void update_char_ptr(char *old_ptr, char *new_ptr);
 void free_all_char_ptrs();
 void register_object(Object *object);
 void free_all_objects();

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -105,6 +105,7 @@ char *handle_include_directive(char *p) {
   // トークナイズ後は元の入力に戻す
   user_input = user_input_prev;
   input_file = input_file_prev;
-  free(new_input); // 読み込んだ内容のメモリを解放
+  // 後でまとめて解放するため登録
+  register_char_ptr(new_input);
   return p;
 }

--- a/src/lexer/tokenize.c
+++ b/src/lexer/tokenize.c
@@ -118,10 +118,11 @@ char *parse_string_literal(char *p) {
   buf = safe_realloc_array(buf, sizeof(char), len + 1, &cap);
   buf[len] = '\0';
   if (token && token->kind == TK_STRING) {
+    char *old = token->str;
     token->str = realloc(token->str, token->len + len + 1);
-    register_char_ptr(token->str);
     if (!token->str)
       error("memory allocation failed");
+    update_char_ptr(old, token->str);
     memcpy(token->str + token->len, buf, len);
     token->len += len;
   } else {

--- a/src/main.c
+++ b/src/main.c
@@ -106,12 +106,11 @@ int main(int argc, char **argv) {
   if (!user_input) {
     error("failed to read source file: %s", input_file);
   }
+  register_char_ptr(user_input);
 
   tokenize();
   new_token(TK_EOF, NULL, NULL, 0);
   token = token_head;
-
-  free(user_input);
 
   program();
 

--- a/src/utils/memory.c
+++ b/src/utils/memory.c
@@ -60,6 +60,16 @@ void register_char_ptr(char *str) {
   char_ptr_list = cl;
 }
 
+void update_char_ptr(char *old_ptr, char *new_ptr) {
+  for (CharPtrList *cl = char_ptr_list; cl; cl = cl->next) {
+    if (cl->str == old_ptr) {
+      cl->str = new_ptr;
+      return;
+    }
+  }
+  register_char_ptr(new_ptr);
+}
+
 void free_all_char_ptrs() {
   CharPtrList *cl = char_ptr_list;
   while (cl) {
@@ -200,7 +210,7 @@ void free_all_strings() {
 void free_all_filenames() {
   while (filenames) {
     FileName *next = filenames->next;
-    // free(filenames->name);
+    free(filenames->name);
     free(filenames);
     filenames = next;
   }


### PR DESCRIPTION
## Summary
- Retain source buffers and include file contents until final teardown
- Track reallocated token strings to avoid double frees during cleanup

## Testing
- `make unittest`
- `make sanitize`


------
https://chatgpt.com/codex/tasks/task_e_68a5f75841388323beb2186c46ca3004