### PR TITLE
Add support for short, long and long long types

### DIFF
--- a/include/lacc.h
+++ b/include/lacc.h
@@ -75,7 +75,21 @@ struct Array {
   int id;
 };
 
-typedef enum { TY_NONE, TY_INT, TY_CHAR, TY_PTR, TY_ARR, TY_ARGARR, TY_VOID, TY_STRUCT, TY_UNION, TY_FUNC } TypeKind;
+typedef enum {
+  TY_NONE,
+  TY_INT,
+  TY_CHAR,
+  TY_SHORT,
+  TY_LONG,
+  TY_LLONG,
+  TY_PTR,
+  TY_ARR,
+  TY_ARGARR,
+  TY_VOID,
+  TY_STRUCT,
+  TY_UNION,
+  TY_FUNC
+} TypeKind;
 
 // Token type
 typedef struct Token Token;
@@ -404,6 +418,7 @@ int compile_time_number();
 //
 
 char *regs1(int i);
+char *regs2(int i);
 char *regs4(int i);
 char *regs8(int i);
 void gen_rodata_section();

--- a/src/codegen/data_section.c
+++ b/src/codegen/data_section.c
@@ -33,7 +33,24 @@ void gen_global_variables() {
     write_file("  .p2align 3\n");
     write_file("%.*s:\n", var->len, var->name);
     if (var->offset) {
-      write_file("  .long %d\n", var->offset);
+      switch (var->type->ty) {
+      case TY_CHAR:
+        write_file("  .byte %d\n", var->offset);
+        break;
+      case TY_SHORT:
+        write_file("  .word %d\n", var->offset);
+        break;
+      case TY_INT:
+        write_file("  .long %d\n", var->offset);
+        break;
+      case TY_LONG:
+      case TY_LLONG:
+      case TY_PTR:
+        write_file("  .quad %d\n", var->offset);
+        break;
+      default:
+        error("invalid type [in gen_global_variables]");
+      }
     } else {
       write_file("  .zero %d\n", get_sizeof(var->type));
     }
@@ -47,7 +64,24 @@ void gen_static_variables() {
     write_file("  .p2align 3\n");
     write_file("%.*s.%d:\n", var->len, var->name, var->block);
     if (var->offset) {
-      write_file("  .long %d\n", var->offset);
+      switch (var->type->ty) {
+      case TY_CHAR:
+        write_file("  .byte %d\n", var->offset);
+        break;
+      case TY_SHORT:
+        write_file("  .word %d\n", var->offset);
+        break;
+      case TY_INT:
+        write_file("  .long %d\n", var->offset);
+        break;
+      case TY_LONG:
+      case TY_LLONG:
+      case TY_PTR:
+        write_file("  .quad %d\n", var->offset);
+        break;
+      default:
+        error("invalid type [in gen_static_variables]");
+      }
     } else {
       write_file("  .zero %d\n", get_sizeof(var->type));
     }
@@ -65,11 +99,23 @@ void gen_array_literals() {
         } else {
           write_file("  .byte %d\n", arr->val[i]);
         }
+      } else if (arr->byte == 2) {
+        if (i >= arr->init) {
+          write_file("  .word 0\n");
+        } else {
+          write_file("  .word %d\n", arr->val[i]);
+        }
       } else if (arr->byte == 4) {
         if (i >= arr->init) {
           write_file("  .long 0\n");
         } else {
           write_file("  .long %d\n", arr->val[i]);
+        }
+      } else if (arr->byte == 8) {
+        if (i >= arr->init) {
+          write_file("  .quad 0\n");
+        } else {
+          write_file("  .quad %d\n", arr->val[i]);
         }
       } else {
         error("invalid array type [in gen_array_literals]");

--- a/src/codegen/gen.c
+++ b/src/codegen/gen.c
@@ -20,6 +20,23 @@ char *regs1(int i) {
     return NULL;
 }
 
+char *regs2(int i) {
+  if (i == 0)
+    return "di";
+  else if (i == 1)
+    return "si";
+  else if (i == 2)
+    return "dx";
+  else if (i == 3)
+    return "cx";
+  else if (i == 4)
+    return "r8w";
+  else if (i == 5)
+    return "r9w";
+  else
+    return NULL;
+}
+
 char *regs4(int i) {
   if (i == 0)
     return "edi";

--- a/src/codegen/text_section.c
+++ b/src/codegen/text_section.c
@@ -180,7 +180,12 @@ void gen(Node *node) {
     case TY_CHAR:
       write_file("  movsx rax, BYTE PTR [rax]\n");
       break;
+    case TY_SHORT:
+      write_file("  movsx rax, WORD PTR [rax]\n");
+      break;
     case TY_PTR:
+    case TY_LONG:
+    case TY_LLONG:
     case TY_ARGARR:
       write_file("  mov rax, QWORD PTR [rax]\n");
       break;
@@ -205,7 +210,12 @@ void gen(Node *node) {
     case TY_CHAR:
       write_file("  movsx rax, BYTE PTR [rax]\n");
       break;
+    case TY_SHORT:
+      write_file("  movsx rax, WORD PTR [rax]\n");
+      break;
     case TY_PTR:
+    case TY_LONG:
+    case TY_LLONG:
     case TY_ARGARR:
       write_file("  mov rax, QWORD PTR [rax]\n");
       break;
@@ -262,7 +272,12 @@ void gen(Node *node) {
       case TY_CHAR:
         write_file("  mov BYTE PTR [rax], dil\n");
         break;
+      case TY_SHORT:
+        write_file("  mov WORD PTR [rax], di\n");
+        break;
       case TY_PTR:
+      case TY_LONG:
+      case TY_LLONG:
         write_file("  mov QWORD PTR [rax], rdi\n");
         break;
       default:
@@ -283,7 +298,12 @@ void gen(Node *node) {
       case TY_CHAR:
         write_file("  movsx rdi, BYTE PTR [rax]\n");
         break;
+      case TY_SHORT:
+        write_file("  movsx rdi, WORD PTR [rax]\n");
+        break;
       case TY_PTR:
+      case TY_LONG:
+      case TY_LLONG:
         write_file("  mov rdi, QWORD PTR [rax]\n");
         break;
       default:
@@ -303,7 +323,12 @@ void gen(Node *node) {
     case TY_CHAR:
       write_file("  mov BYTE PTR [rax], dil\n");
       break;
+    case TY_SHORT:
+      write_file("  mov WORD PTR [rax], di\n");
+      break;
     case TY_PTR:
+    case TY_LONG:
+    case TY_LLONG:
       write_file("  mov QWORD PTR [rax], rdi\n");
       break;
     default:
@@ -441,6 +466,12 @@ void gen(Node *node) {
     case TY_CHAR:
       write_file("  movsx rax, al\n");
       break;
+    case TY_SHORT:
+      write_file("  movsx rax, ax\n");
+      break;
+    case TY_LONG:
+    case TY_LLONG:
+      break;
     case TY_PTR:
     case TY_ARR:
     case TY_ARGARR:
@@ -479,6 +510,13 @@ void gen(Node *node) {
       case TY_CHAR:
         write_file("  mov BYTE PTR [rax], %s\n", regs1(i));
         break;
+      case TY_SHORT:
+        write_file("  mov WORD PTR [rax], %s\n", regs2(i));
+        break;
+      case TY_LONG:
+      case TY_LLONG:
+        write_file("  mov QWORD PTR [rax], %s\n", regs8(i));
+        break;
       case TY_PTR:
       case TY_ARGARR:
         write_file("  mov QWORD PTR [rax], %s\n", regs8(i));
@@ -511,6 +549,13 @@ void gen(Node *node) {
         break;
       case TY_CHAR:
         write_file("  movsx %s, al\n", regs4(i));
+        break;
+      case TY_SHORT:
+        write_file("  movsx %s, ax\n", regs4(i));
+        break;
+      case TY_LONG:
+      case TY_LLONG:
+        write_file("  mov %s, rax\n", regs8(i));
         break;
       case TY_PTR:
       case TY_ARR:

--- a/src/lexer/tokenize.c
+++ b/src/lexer/tokenize.c
@@ -352,6 +352,29 @@ void tokenize() {
       continue;
     }
 
+    if (startswith(p, "short") && !is_alnum(p[5])) {
+      new_token(TK_TYPE, p, p, 5);
+      token->ty = TY_SHORT;
+      p += 5;
+      continue;
+    }
+
+    if (startswith(p, "long") && !is_alnum(p[4])) {
+      char *q = p + 4;
+      while (isspace(*q))
+        q++;
+      if (startswith(q, "long") && !is_alnum(q[4])) {
+        new_token(TK_TYPE, p, p, q + 4 - p);
+        token->ty = TY_LLONG;
+        p = q + 4;
+      } else {
+        new_token(TK_TYPE, p, p, 4);
+        token->ty = TY_LONG;
+        p += 4;
+      }
+      continue;
+    }
+
     if (startswith(p, "int") && !is_alnum(p[3])) {
       new_token(TK_TYPE, p, p, 3);
       token->ty = TY_INT;

--- a/src/types/type.c
+++ b/src/types/type.c
@@ -76,6 +76,13 @@ Type *parse_base_type_internal(const int should_consume, const int should_record
   } else {
     type->ty = token->ty;
     token = token->next;
+    if (type->ty == TY_LONG && token->kind == TK_TYPE && token->ty == TY_LONG) {
+      type->ty = TY_LLONG;
+      token = token->next;
+    }
+    if ((type->ty == TY_LONG || type->ty == TY_SHORT || type->ty == TY_LLONG) && token->kind == TK_TYPE && token->ty == TY_INT) {
+      token = token->next;
+    }
   }
 
   // 後続のconst
@@ -265,6 +272,10 @@ int get_sizeof(Type *type) {
     return 4;
   case TY_CHAR:
     return 1;
+  case TY_SHORT:
+    return 2;
+  case TY_LONG:
+  case TY_LLONG:
   case TY_PTR:
     return 8;
   case TY_ARR:
@@ -290,6 +301,10 @@ int type_size(Type *type) {
     return 4;
   case TY_CHAR:
     return 1;
+  case TY_SHORT:
+    return 2;
+  case TY_LONG:
+  case TY_LLONG:
   case TY_PTR:
   case TY_ARR:
   case TY_ARGARR:
@@ -304,12 +319,18 @@ int type_size(Type *type) {
 }
 
 int is_ptr_or_arr(Type *type) { return type->ty == TY_PTR || type->ty == TY_ARR || type->ty == TY_ARGARR; }
-int is_number(Type *type) { return type->ty == TY_INT || type->ty == TY_CHAR; }
+int is_number(Type *type) {
+  return type->ty == TY_INT || type->ty == TY_CHAR || type->ty == TY_SHORT || type->ty == TY_LONG ||
+         type->ty == TY_LLONG;
+}
 
 char *type_name(Type *type) {
   switch (type->ty) {
   case TY_INT:
   case TY_CHAR:
+  case TY_SHORT:
+  case TY_LONG:
+  case TY_LLONG:
     return "integer";
   case TY_PTR:
     return "pointer";

--- a/tests/unittest.c
+++ b/tests/unittest.c
@@ -1571,6 +1571,30 @@ int test165() {
   return a || b ? 5 : 9; /* (0||1)=真 -> 5 */
 }
 
+int test166() {
+  short a = 3;
+  short b = 4;
+  return a + b;
+}
+
+int test167() {
+  long a = 5;
+  long b = 7;
+  return a + b;
+}
+
+int test168() {
+  long long a = 5;
+  long long b = 7;
+  return a + b;
+}
+
+int test169() { return sizeof(short); }
+
+int test170() { return sizeof(long); }
+
+int test171() { return sizeof(long long); }
+
 int test_cnt = 0;
 void check(int result, int id, int ans) {
   test_cnt++;
@@ -1747,6 +1771,12 @@ int main() {
   check(test163(), 163, 45);
   check(test164(), 164, 2);
   check(test165(), 165, 5);
+  check(test166(), 166, 7);
+  check(test167(), 167, 12);
+  check(test168(), 168, 12);
+  check(test169(), 169, 2);
+  check(test170(), 170, 8);
+  check(test171(), 171, 8);
 
   if (failures == 0) {
     printf("\033[1;36mAll %d tests passed!\033[0m\n", test_cnt);


### PR DESCRIPTION
## Summary
- Support `short`, `long`, and `long long` types with new tokenizer rules and type kinds
- Handle these types in size calculation, code generation, and data section emission
- Add unit tests for new integer types

## Testing
- `make unittest`

------
https://chatgpt.com/codex/tasks/task_e_68a6d0269320832397622910f33e44af