### PR TITLE
Support short and long integer types

### DIFF
--- a/src/types/type.c
+++ b/src/types/type.c
@@ -40,6 +40,14 @@ Type *new_type_arr(Type *ptr_to, int array_size) {
   return type;
 }
 
+// consume a token of TK_TYPE with the specified keyword
+static int consume_type_kw(char *kw) {
+  if (token->kind != TK_TYPE || strlen(kw) != token->len || strncmp(token->str, kw, token->len))
+    return FALSE;
+  token = token->next;
+  return TRUE;
+}
+
 Type *parse_base_type_internal(const int should_consume, const int should_record) {
   Token *tok = token;
   Type *type = new_type(TY_NONE);
@@ -72,19 +80,23 @@ Type *parse_base_type_internal(const int should_consume, const int should_record
     }
     token = token->next;
   } else if (token->kind == TK_TYPE) {
-    if (consume("int"))
+    if (consume_type_kw("int"))
       type->ty = TY_INT;
-    else if (consume("char"))
+    else if (consume_type_kw("char"))
       type->ty = TY_CHAR;
-    else if (consume("short"))
+    else if (consume_type_kw("short"))
       type->ty = TY_SHORT;
-    else if (consume("long")) {
-      if (consume("long"))
+    else if (consume_type_kw("long")) {
+      if (consume_type_kw("long"))
         type->ty = TY_LONGLONG;
       else
         type->ty = TY_LONG;
+    } else if (consume_type_kw("void")) {
+      type->ty = TY_VOID;
+    } else {
+      return NULL;
     }
-    token = token->next;
+    consume_type_kw("int");
   } else {
     return NULL;
   }

--- a/tests/unittest.c
+++ b/tests/unittest.c
@@ -1571,6 +1571,12 @@ int test165() {
   return a || b ? 5 : 9; /* (0||1)=真 -> 5 */
 }
 
+int test166() { return sizeof(short); }
+
+int test167() { return sizeof(long); }
+
+int test168() { return sizeof(long long); }
+
 int test_cnt = 0;
 void check(int result, int id, int ans) {
   test_cnt++;
@@ -1747,6 +1753,9 @@ int main() {
   check(test163(), 163, 45);
   check(test164(), 164, 2);
   check(test165(), 165, 5);
+  check(test166(), 166, 2);
+  check(test167(), 167, 8);
+  check(test168(), 168, 8);
 
   if (failures == 0) {
     printf("\033[1;36mAll %d tests passed!\033[0m\n", test_cnt);


### PR DESCRIPTION
## Summary
- Parse `short`, `long`, and `long long` type keywords correctly
- Add unit tests for the new integer type sizes

## Testing
- `make unittest`


------
https://chatgpt.com/codex/tasks/task_e_68a6d3f0074c83238267e59aa21bc4d5