### PR TITLE
Add support for short, long and long long types

### DIFF
--- a/include/lacc.h
+++ b/include/lacc.h
@@ -75,7 +75,21 @@ struct Array {
   int id;
 };
 
-typedef enum { TY_NONE, TY_INT, TY_CHAR, TY_PTR, TY_ARR, TY_ARGARR, TY_VOID, TY_STRUCT, TY_UNION, TY_FUNC } TypeKind;
+typedef enum {
+  TY_NONE,
+  TY_INT,
+  TY_CHAR,
+  TY_SHORT,
+  TY_LONG,
+  TY_LONGLONG,
+  TY_PTR,
+  TY_ARR,
+  TY_ARGARR,
+  TY_VOID,
+  TY_STRUCT,
+  TY_UNION,
+  TY_FUNC
+} TypeKind;
 
 // Token type
 typedef struct Token Token;
@@ -404,6 +418,7 @@ int compile_time_number();
 //
 
 char *regs1(int i);
+char *regs2(int i);
 char *regs4(int i);
 char *regs8(int i);
 void gen_rodata_section();

--- a/src/codegen/data_section.c
+++ b/src/codegen/data_section.c
@@ -33,7 +33,17 @@ void gen_global_variables() {
     write_file("  .p2align 3\n");
     write_file("%.*s:\n", var->len, var->name);
     if (var->offset) {
-      write_file("  .long %d\n", var->offset);
+      int sz = get_sizeof(var->type);
+      if (sz == 1)
+        write_file("  .byte %d\n", var->offset);
+      else if (sz == 2)
+        write_file("  .word %d\n", var->offset);
+      else if (sz == 4)
+        write_file("  .long %d\n", var->offset);
+      else if (sz == 8)
+        write_file("  .quad %d\n", var->offset);
+      else
+        error("invalid type size [in gen_global_variables]");
     } else {
       write_file("  .zero %d\n", get_sizeof(var->type));
     }
@@ -47,7 +57,17 @@ void gen_static_variables() {
     write_file("  .p2align 3\n");
     write_file("%.*s.%d:\n", var->len, var->name, var->block);
     if (var->offset) {
-      write_file("  .long %d\n", var->offset);
+      int sz = get_sizeof(var->type);
+      if (sz == 1)
+        write_file("  .byte %d\n", var->offset);
+      else if (sz == 2)
+        write_file("  .word %d\n", var->offset);
+      else if (sz == 4)
+        write_file("  .long %d\n", var->offset);
+      else if (sz == 8)
+        write_file("  .quad %d\n", var->offset);
+      else
+        error("invalid type size [in gen_static_variables]");
     } else {
       write_file("  .zero %d\n", get_sizeof(var->type));
     }

--- a/src/codegen/gen.c
+++ b/src/codegen/gen.c
@@ -20,6 +20,23 @@ char *regs1(int i) {
     return NULL;
 }
 
+char *regs2(int i) {
+  if (i == 0)
+    return "di";
+  else if (i == 1)
+    return "si";
+  else if (i == 2)
+    return "dx";
+  else if (i == 3)
+    return "cx";
+  else if (i == 4)
+    return "r8w";
+  else if (i == 5)
+    return "r9w";
+  else
+    return NULL;
+}
+
 char *regs4(int i) {
   if (i == 0)
     return "edi";

--- a/src/codegen/text_section.c
+++ b/src/codegen/text_section.c
@@ -180,6 +180,11 @@ void gen(Node *node) {
     case TY_CHAR:
       write_file("  movsx rax, BYTE PTR [rax]\n");
       break;
+    case TY_SHORT:
+      write_file("  movsx rax, WORD PTR [rax]\n");
+      break;
+    case TY_LONG:
+    case TY_LONGLONG:
     case TY_PTR:
     case TY_ARGARR:
       write_file("  mov rax, QWORD PTR [rax]\n");
@@ -205,6 +210,11 @@ void gen(Node *node) {
     case TY_CHAR:
       write_file("  movsx rax, BYTE PTR [rax]\n");
       break;
+    case TY_SHORT:
+      write_file("  movsx rax, WORD PTR [rax]\n");
+      break;
+    case TY_LONG:
+    case TY_LONGLONG:
     case TY_PTR:
     case TY_ARGARR:
       write_file("  mov rax, QWORD PTR [rax]\n");
@@ -262,6 +272,11 @@ void gen(Node *node) {
       case TY_CHAR:
         write_file("  mov BYTE PTR [rax], dil\n");
         break;
+      case TY_SHORT:
+        write_file("  mov WORD PTR [rax], di\n");
+        break;
+      case TY_LONG:
+      case TY_LONGLONG:
       case TY_PTR:
         write_file("  mov QWORD PTR [rax], rdi\n");
         break;
@@ -283,6 +298,11 @@ void gen(Node *node) {
       case TY_CHAR:
         write_file("  movsx rdi, BYTE PTR [rax]\n");
         break;
+      case TY_SHORT:
+        write_file("  movsx rdi, WORD PTR [rax]\n");
+        break;
+      case TY_LONG:
+      case TY_LONGLONG:
       case TY_PTR:
         write_file("  mov rdi, QWORD PTR [rax]\n");
         break;
@@ -303,6 +323,11 @@ void gen(Node *node) {
     case TY_CHAR:
       write_file("  mov BYTE PTR [rax], dil\n");
       break;
+    case TY_SHORT:
+      write_file("  mov WORD PTR [rax], di\n");
+      break;
+    case TY_LONG:
+    case TY_LONGLONG:
     case TY_PTR:
       write_file("  mov QWORD PTR [rax], rdi\n");
       break;
@@ -441,10 +466,15 @@ void gen(Node *node) {
     case TY_CHAR:
       write_file("  movsx rax, al\n");
       break;
+    case TY_SHORT:
+      write_file("  movsx rax, ax\n");
+      break;
     case TY_PTR:
     case TY_ARR:
     case TY_ARGARR:
-      // No conversion needed for pointers
+    case TY_LONG:
+    case TY_LONGLONG:
+      // No conversion needed for pointers or 64-bit integers
       break;
     default:
       error("invalid type [in ND_TYPECAST]");
@@ -479,6 +509,11 @@ void gen(Node *node) {
       case TY_CHAR:
         write_file("  mov BYTE PTR [rax], %s\n", regs1(i));
         break;
+      case TY_SHORT:
+        write_file("  mov WORD PTR [rax], %s\n", regs2(i));
+        break;
+      case TY_LONG:
+      case TY_LONGLONG:
       case TY_PTR:
       case TY_ARGARR:
         write_file("  mov QWORD PTR [rax], %s\n", regs8(i));
@@ -512,6 +547,11 @@ void gen(Node *node) {
       case TY_CHAR:
         write_file("  movsx %s, al\n", regs4(i));
         break;
+      case TY_SHORT:
+        write_file("  movsx %s, ax\n", regs4(i));
+        break;
+      case TY_LONG:
+      case TY_LONGLONG:
       case TY_PTR:
       case TY_ARR:
       case TY_ARGARR:

--- a/src/lexer/tokenize.c
+++ b/src/lexer/tokenize.c
@@ -352,6 +352,29 @@ void tokenize() {
       continue;
     }
 
+    if (startswith(p, "long") && !is_alnum(p[4])) {
+      char *q = p + 4;
+      while (isspace(*q))
+        q++;
+      if (startswith(q, "long") && !is_alnum(q[4])) {
+        new_token(TK_TYPE, p, p, q + 4 - p);
+        token->ty = TY_LONGLONG;
+        p = q + 4;
+        continue;
+      }
+      new_token(TK_TYPE, p, p, 4);
+      token->ty = TY_LONG;
+      p += 4;
+      continue;
+    }
+
+    if (startswith(p, "short") && !is_alnum(p[5])) {
+      new_token(TK_TYPE, p, p, 5);
+      token->ty = TY_SHORT;
+      p += 5;
+      continue;
+    }
+
     if (startswith(p, "int") && !is_alnum(p[3])) {
       new_token(TK_TYPE, p, p, 3);
       token->ty = TY_INT;

--- a/src/types/type.c
+++ b/src/types/type.c
@@ -265,6 +265,11 @@ int get_sizeof(Type *type) {
     return 4;
   case TY_CHAR:
     return 1;
+  case TY_SHORT:
+    return 2;
+  case TY_LONG:
+  case TY_LONGLONG:
+    return 8;
   case TY_PTR:
     return 8;
   case TY_ARR:
@@ -290,6 +295,11 @@ int type_size(Type *type) {
     return 4;
   case TY_CHAR:
     return 1;
+  case TY_SHORT:
+    return 2;
+  case TY_LONG:
+  case TY_LONGLONG:
+    return 8;
   case TY_PTR:
   case TY_ARR:
   case TY_ARGARR:
@@ -304,12 +314,18 @@ int type_size(Type *type) {
 }
 
 int is_ptr_or_arr(Type *type) { return type->ty == TY_PTR || type->ty == TY_ARR || type->ty == TY_ARGARR; }
-int is_number(Type *type) { return type->ty == TY_INT || type->ty == TY_CHAR; }
+int is_number(Type *type) {
+  return type->ty == TY_INT || type->ty == TY_CHAR || type->ty == TY_SHORT || type->ty == TY_LONG ||
+         type->ty == TY_LONGLONG;
+}
 
 char *type_name(Type *type) {
   switch (type->ty) {
   case TY_INT:
   case TY_CHAR:
+  case TY_SHORT:
+  case TY_LONG:
+  case TY_LONGLONG:
     return "integer";
   case TY_PTR:
     return "pointer";

--- a/tests/unittest.c
+++ b/tests/unittest.c
@@ -1571,6 +1571,23 @@ int test165() {
   return a || b ? 5 : 9; /* (0||1)=真 -> 5 */
 }
 
+int test166() {
+  short a = 5;
+  return sizeof(a) + a; /* 2 + 5 = 7 */
+}
+
+int test167() {
+  long a = 3;
+  long b = 4;
+  return sizeof(a) + a * b; /* 8 + 12 = 20 */
+}
+
+int test168() {
+  long long a = 1;
+  long long b = 2;
+  return sizeof(a) + a + b; /* 8 + 1 + 2 = 11 */
+}
+
 int test_cnt = 0;
 void check(int result, int id, int ans) {
   test_cnt++;
@@ -1747,6 +1764,9 @@ int main() {
   check(test163(), 163, 45);
   check(test164(), 164, 2);
   check(test165(), 165, 5);
+  check(test166(), 166, 7);
+  check(test167(), 167, 20);
+  check(test168(), 168, 11);
 
   if (failures == 0) {
     printf("\033[1;36mAll %d tests passed!\033[0m\n", test_cnt);


### PR DESCRIPTION
## Summary
- handle `short`, `long` and `long long` in tokenizer, type system and code generation
- emit correct size directives and registers for the new integer widths
- add regression tests covering the additional integer types

## Testing
- `make unittest`
- `make warntest`
- `make errortest`


------
https://chatgpt.com/codex/tasks/task_e_68a72f6c2f588323be86102bdd249e26