### PR TITLE
LVar::offset、Function::offset を削除

### DIFF
--- a/include/mir.h
+++ b/include/mir.h
@@ -115,12 +115,19 @@ struct MirFunction {
   int next_vreg;
   int next_label;
   int param_count;
-  int param_offsets[MAX_FUNC_PARAMS];
+  int param_slots[MAX_FUNC_PARAMS];
   Type *param_types[MAX_FUNC_PARAMS];
+  LVar **local_vars;
+  Type **local_types;
+  int *local_sizes;
+  int local_count;
+  int local_cap;
 };
 
 VReg mir_new_vreg(MirFunction *mf);
 int mir_new_label(MirFunction *mf);
+int mir_get_or_add_local_slot(MirFunction *mf, LVar *var, Type *type, int size);
+int mir_add_local_slot(MirFunction *mf, LVar *var, Type *type, int size);
 void mir_emit(MirFunction *mf, const MirInst *inst);
 void mir_dump(FILE *out, const MirFunction *mf);
 void mir_free(MirFunction *mf);

--- a/include/parser.h
+++ b/include/parser.h
@@ -27,7 +27,6 @@ struct Array {
   int id;
 };
 
-typedef struct StructLiteral StructLiteral;
 typedef struct StructReloc StructReloc;
 struct StructReloc {
   StructReloc *next;
@@ -35,6 +34,7 @@ struct StructReloc {
   String *str;
 };
 
+typedef struct StructLiteral StructLiteral;
 struct StructLiteral {
   StructLiteral *next;
   unsigned char *data;
@@ -89,7 +89,9 @@ struct LVar {
   LVar *next;
   char *name;
   int len;
-  int offset;
+  int member_offset;
+  long long init_value;
+  int has_init_value;
   int is_extern;
   Type *type;
   int is_static;
@@ -149,7 +151,6 @@ struct Function {
   Function *next;
   char *name;
   int len;
-  int offset;
   int is_static;
   Label *labels;
   Type *type;

--- a/src/codegen/data_section.c
+++ b/src/codegen/data_section.c
@@ -112,16 +112,16 @@ static void gen_global_variables(int *data_emitted) {
       write_array_data(var->init_array);
     } else if (var->init_struct) {
       write_struct_data(var->init_struct);
-    } else if (var->offset) {
+    } else if (var->has_init_value) {
       int sz = get_sizeof(var->type);
       if (sz == 1)
-        write_file("  .byte %d\n", var->offset);
+        write_file("  .byte %lld\n", var->init_value);
       else if (sz == 2)
-        write_file("  .word %d\n", var->offset);
+        write_file("  .word %lld\n", var->init_value);
       else if (sz == 4)
-        write_file("  .long %d\n", var->offset);
+        write_file("  .long %lld\n", var->init_value);
       else if (sz == 8)
-        write_file("  .quad %d\n", var->offset);
+        write_file("  .quad %lld\n", var->init_value);
       else
         error("invalid type size [in gen_global_variables]");
     } else {
@@ -143,16 +143,16 @@ static void gen_static_variables(int *data_emitted) {
       write_array_data(var->init_array);
     } else if (var->init_struct) {
       write_struct_data(var->init_struct);
-    } else if (var->offset) {
+    } else if (var->has_init_value) {
       int sz = get_sizeof(var->type);
       if (sz == 1)
-        write_file("  .byte %d\n", var->offset);
+        write_file("  .byte %lld\n", var->init_value);
       else if (sz == 2)
-        write_file("  .word %d\n", var->offset);
+        write_file("  .word %lld\n", var->init_value);
       else if (sz == 4)
-        write_file("  .long %d\n", var->offset);
+        write_file("  .long %lld\n", var->init_value);
       else if (sz == 8)
-        write_file("  .quad %d\n", var->offset);
+        write_file("  .quad %lld\n", var->init_value);
       else
         error("invalid type size [in gen_static_variables]");
     } else {

--- a/src/codegen/lower/lower.c
+++ b/src/codegen/lower/lower.c
@@ -76,6 +76,12 @@ static void init_inst(MirInst *inst, MirOp op) {
 
 static inline int new_label(LowerCtx *ctx) { return mir_new_label(ctx->mf); }
 
+static int local_slot(LowerCtx *ctx, LVar *var) {
+  if (!ctx || !ctx->mf || !var || !var->type)
+    error("invalid local variable [in local_slot]");
+  return mir_get_or_add_local_slot(ctx->mf, var, var->type, get_sizeof(var->type));
+}
+
 static void emit_label(LowerCtx *ctx, int label) {
   MirInst inst;
   init_inst(&inst, MIR_OP_LABEL);
@@ -739,7 +745,7 @@ static VReg lower_addr(LowerCtx *ctx, Node *node) {
   if (node->kind == ND_LVAR || node->kind == ND_VARDEC) {
     if (!node->var->is_static) {
       inst.op = MIR_OP_ADDR_LOCAL;
-      inst.offset = node->var->offset;
+      inst.offset = local_slot(ctx, node->var);
       inst.var = NULL;
     }
   }
@@ -787,7 +793,7 @@ static VReg lower_direct_local_load(LowerCtx *ctx, const Node *node) {
   MirInst load;
   init_inst(&load, MIR_OP_LOAD_LOCAL);
   load.dst = dst;
-  load.offset = node->var->offset;
+  load.offset = local_slot(ctx, node->var);
   load.type = type;
   mir_emit(ctx->mf, &load);
   return dst;
@@ -798,7 +804,7 @@ static void lower_direct_local_store(LowerCtx *ctx, const Node *node, VReg value
   MirInst store;
   init_inst(&store, MIR_OP_STORE_LOCAL);
   store.src1 = value;
-  store.offset = node->var->offset;
+  store.offset = local_slot(ctx, node->var);
   store.type = type;
   mir_emit(ctx->mf, &store);
 }
@@ -1316,8 +1322,10 @@ void lower_function(Node *fn_node, MirFunction *mf) {
   for (int i = 0; i < mf->param_count; i++) {
     if (!fn_node->args[i] || !fn_node->args[i]->var)
       lower_error_node("invalid function parameter node in lowering", fn_node);
-    mf->param_offsets[i] = fn_node->args[i]->var->offset;
     mf->param_types[i] = fn_node->args[i]->type;
+    Type *type = fn_node->args[i]->type;
+    int size = is_ptr_or_arr(type) ? 8 : get_sizeof(type);
+    mf->param_slots[i] = mir_get_or_add_local_slot(mf, fn_node->args[i]->var, type, size);
   }
 
   LowerCtx ctx = {0};

--- a/src/codegen/lower/pipeline.c
+++ b/src/codegen/lower/pipeline.c
@@ -47,20 +47,6 @@ static int find_lowered_function_index(Function **fns, int fn_count, Function *t
   return -1;
 }
 
-static int mir_local_max_offset(const MirFunction *mf) {
-  if (!mf)
-    return 0;
-  int max_off = 0;
-  for (int i = 0; i < mf->blocks[0].inst_len; i++) {
-    MirOp op = mf->blocks[0].insts[i].op;
-    if (op != MIR_OP_LOAD_LOCAL && op != MIR_OP_STORE_LOCAL && op != MIR_OP_ADDR_LOCAL)
-      continue;
-    if (mf->blocks[0].insts[i].offset > max_off)
-      max_off = mf->blocks[0].insts[i].offset;
-  }
-  return max_off;
-}
-
 static int mir_inline_cost(const MirFunction *mf) {
   if (!mf)
     return 0;
@@ -216,15 +202,13 @@ static int should_inline_callsite(const MirFunction *caller, const MirFunction *
 }
 
 static void expand_inline_callsite(MirFunction *caller, const MirFunction *callee, const MirInst *call, MirInst **out,
-                                   int *out_len, int *out_cap, int *caller_local_max) {
-  if (!caller || !callee || !call || !out || !out_len || !out_cap || !caller_local_max)
+                                   int *out_len, int *out_cap) {
+  if (!caller || !callee || !call || !out || !out_len || !out_cap)
     error("invalid inline expansion state");
 
-  int local_max = *caller_local_max;
-  int offset_delta = ((local_max + 7) / 8) * 8;
-  int callee_local_max = mir_local_max_offset(callee);
-  if (offset_delta + callee_local_max > *caller_local_max)
-    *caller_local_max = offset_delta + callee_local_max;
+  int slot_delta = caller->local_count;
+  for (int i = 0; i < callee->local_count; i++)
+    mir_add_local_slot(caller, callee->local_vars[i], callee->local_types[i], callee->local_sizes[i]);
 
   VReg *vmap = NULL;
   if (callee->next_vreg > 0) {
@@ -248,7 +232,7 @@ static void expand_inline_callsite(MirFunction *caller, const MirFunction *calle
   for (int i = 0; i < callee->param_count; i++) {
     MirInst st;
     init_inst(&st, MIR_OP_STORE_LOCAL);
-    st.offset = callee->param_offsets[i] + offset_delta;
+    st.offset = callee->param_slots[i] + slot_delta;
     st.type = callee->param_types[i];
     st.src1 = call->args[i];
     append_inst_inline(out, out_len, out_cap, &st);
@@ -280,7 +264,7 @@ static void expand_inline_callsite(MirFunction *caller, const MirFunction *calle
       out_in.args[a] = remap_inline_vreg(vmap, callee->next_vreg, out_in.args[a]);
 
     if (out_in.op == MIR_OP_LOAD_LOCAL || out_in.op == MIR_OP_STORE_LOCAL || out_in.op == MIR_OP_ADDR_LOCAL)
-      out_in.offset += offset_delta;
+      out_in.offset += slot_delta;
 
     if (out_in.op == MIR_OP_LABEL || out_in.op == MIR_OP_JMP || out_in.op == MIR_OP_JZ || out_in.op == MIR_OP_JCC) {
       if (!label_map || out_in.label < 0 || out_in.label >= callee->next_label)
@@ -307,7 +291,6 @@ static int run_inline_in_function(MirFunction *caller, MirFunction *mfs, Functio
     return 0;
 
   int changed = 0;
-  int caller_local_max = mir_local_max_offset(caller);
   MirInst *out = NULL;
   int out_len = 0;
   int out_cap = 0;
@@ -318,7 +301,7 @@ static int run_inline_in_function(MirFunction *caller, MirFunction *mfs, Functio
       int callee_idx = find_lowered_function_index(fns, fn_count, in->call_fn);
       if (callee_idx >= 0 && should_inline_callsite(caller, &mfs[callee_idx], in, optimize_level, caller_idx,
                                                     callee_idx, reach, fn_count, site_info)) {
-        expand_inline_callsite(caller, &mfs[callee_idx], in, &out, &out_len, &out_cap, &caller_local_max);
+        expand_inline_callsite(caller, &mfs[callee_idx], in, &out, &out_len, &out_cap);
         changed = 1;
         continue;
       }
@@ -336,6 +319,46 @@ static int run_inline_in_function(MirFunction *caller, MirFunction *mfs, Functio
   caller->blocks[0].inst_len = out_len;
   caller->blocks[0].inst_cap = out_cap;
   return 1;
+}
+
+static void assign_local_offsets(MirFunction *mf) {
+  if (!mf || mf->local_count <= 0)
+    return;
+
+  unsigned char *used = calloc(mf->local_count, sizeof(unsigned char));
+  int *offsets = calloc(mf->local_count, sizeof(int));
+  if (!used || !offsets)
+    error("memory allocation failed [in assign_local_offsets]");
+
+  for (int i = 0; i < mf->blocks[0].inst_len; i++) {
+    MirInst *in = &mf->blocks[0].insts[i];
+    if (in->op != MIR_OP_LOAD_LOCAL && in->op != MIR_OP_STORE_LOCAL && in->op != MIR_OP_ADDR_LOCAL)
+      continue;
+    if (in->offset <= 0 || in->offset > mf->local_count)
+      error("invalid local slot [in assign_local_offsets]");
+    used[in->offset - 1] = 1;
+  }
+
+  int offset = 0;
+  for (int i = 0; i < mf->local_count; i++) {
+    if (!used[i])
+      continue;
+    offset += mf->local_sizes[i];
+    offsets[i] = offset;
+  }
+
+  for (int i = 0; i < mf->blocks[0].inst_len; i++) {
+    MirInst *in = &mf->blocks[0].insts[i];
+    if (in->op == MIR_OP_LOAD_LOCAL || in->op == MIR_OP_STORE_LOCAL || in->op == MIR_OP_ADDR_LOCAL)
+      in->offset = offsets[in->offset - 1];
+  }
+  for (int i = 0; i < mf->param_count; i++) {
+    int slot = mf->param_slots[i];
+    mf->param_slots[i] = slot > 0 && slot <= mf->local_count ? offsets[slot - 1] : 0;
+  }
+
+  free(offsets);
+  free(used);
 }
 
 static void build_call_reachability(const MirFunction *mfs, Function **fns, int fn_count, unsigned char *reach) {
@@ -444,6 +467,8 @@ void emit_mir_program_pipeline(int dump_mir, int optimize_level) {
   }
   for (int i = 0; i < fn_count; i++)
     ssa_destruct(&mfs[i]);
+  for (int i = 0; i < fn_count; i++)
+    assign_local_offsets(&mfs[i]);
 
   int qh = 0;
   int qt = 0;

--- a/src/codegen/mir/emit_inst.c
+++ b/src/codegen/mir/emit_inst.c
@@ -1785,7 +1785,7 @@ void emit_mir_function_codegen(const MirFunction *mf) {
   int emit_epilogue_label = needs_epilogue_label(mf);
 
   for (int i = 0; i < mf->param_count; i++) {
-    int off = mf->param_offsets[i];
+    int off = mf->param_slots[i];
     if (!mir_uses_local_offset(mf, off))
       continue;
     Type *ty = mf->param_types[i];

--- a/src/codegen/mir/mir.c
+++ b/src/codegen/mir/mir.c
@@ -112,6 +112,38 @@ int mir_new_label(MirFunction *mf) {
   return mf->next_label++;
 }
 
+int mir_add_local_slot(MirFunction *mf, LVar *var, Type *type, int size) {
+  if (!mf || !type || size <= 0)
+    error("invalid local slot [in mir_add_local_slot]");
+  if (mf->local_count >= mf->local_cap) {
+    int cap = mf->local_cap ? mf->local_cap * 2 : 16;
+    LVar **new_vars = realloc(mf->local_vars, sizeof(LVar *) * cap);
+    Type **new_types = realloc(mf->local_types, sizeof(Type *) * cap);
+    int *new_sizes = realloc(mf->local_sizes, sizeof(int) * cap);
+    if (!new_vars || !new_types || !new_sizes)
+      error("memory allocation failed [in mir_add_local_slot]");
+    mf->local_vars = new_vars;
+    mf->local_types = new_types;
+    mf->local_sizes = new_sizes;
+    mf->local_cap = cap;
+  }
+  int slot = mf->local_count++;
+  mf->local_vars[slot] = var;
+  mf->local_types[slot] = type;
+  mf->local_sizes[slot] = size;
+  return slot + 1;
+}
+
+int mir_get_or_add_local_slot(MirFunction *mf, LVar *var, Type *type, int size) {
+  if (!mf || !var)
+    error("invalid local variable [in mir_get_or_add_local_slot]");
+  for (int i = 0; i < mf->local_count; i++) {
+    if (mf->local_vars[i] == var)
+      return i + 1;
+  }
+  return mir_add_local_slot(mf, var, type, size);
+}
+
 int mir_new_block(MirFunction *mf) {
   if (!mf)
     return -1;
@@ -342,9 +374,17 @@ void mir_free(MirFunction *mf) {
     free(bb->preds);
   }
   free(mf->blocks);
+  free(mf->local_vars);
+  free(mf->local_types);
+  free(mf->local_sizes);
   mf->blocks = NULL;
+  mf->local_vars = NULL;
+  mf->local_types = NULL;
+  mf->local_sizes = NULL;
   mf->block_count = 0;
   mf->block_cap = 0;
+  mf->local_count = 0;
+  mf->local_cap = 0;
   mf->next_vreg = 0;
   mf->next_label = 0;
   mf->fn = NULL;

--- a/src/parser/builtin.c
+++ b/src/parser/builtin.c
@@ -26,7 +26,6 @@ static Function *create_function_entry(const char *name) {
   functions = fn;
   fn->name = (char *)name;
   fn->len = (int)strlen(name);
-  fn->offset = 0;
   fn->is_static = false;
   fn->labels = NULL;
   fn->type = NULL;
@@ -46,7 +45,6 @@ static Function *ensure_function_entry(const char *name) {
 }
 
 static void configure_common_fields(Function *fn, Type *type) {
-  fn->offset = 0;
   fn->is_static = false;
   fn->labels = NULL;
   fn->type = type;

--- a/src/parser/decl.c
+++ b/src/parser/decl.c
@@ -82,7 +82,7 @@ static int has_return_stmt(Node *n) {
   return false;
 }
 
-Node *handle_array_initialization(Node *node, LVar *lvar, Type *type, int set_offset) {
+Node *handle_array_initialization(Node *node, LVar *lvar, Type *type, int is_static_storage) {
   Array *array = array_literal(type);
   if (type->ty == TY_ARR) {
     if (type->array_size == 0) {
@@ -91,7 +91,7 @@ Node *handle_array_initialization(Node *node, LVar *lvar, Type *type, int set_of
       warning_at(consumed_loc, "excess elements in array initializer [in variable declaration]");
     }
     array->len = get_sizeof(type) / array->byte;
-    if (set_offset) {
+    if (is_static_storage) {
       if (lvar)
         lvar->init_array = array;
       node->type = type;
@@ -110,7 +110,7 @@ Node *handle_array_initialization(Node *node, LVar *lvar, Type *type, int set_of
   arr_node->type = type;
   arr_node->id = array->id;
   if (type->ty == TY_PTR) {
-    if (set_offset) {
+    if (is_static_storage) {
       if (lvar)
         lvar->init_array = array;
       node->type = type;
@@ -160,9 +160,9 @@ Node *handle_scalar_initialization(Node *node, Type *type, Location *loc) {
   return node;
 }
 
-Node *handle_struct_initialization(Node *node, LVar *lvar, Type *type, int set_offset) {
+Node *handle_struct_initialization(Node *node, LVar *lvar, Type *type, int is_static_storage) {
   StructLiteral *literal = struct_literal(type);
-  if (set_offset) {
+  if (is_static_storage) {
     if (lvar)
       lvar->init_struct = literal;
     node->type = type;
@@ -179,22 +179,21 @@ Node *handle_struct_initialization(Node *node, LVar *lvar, Type *type, int set_o
 }
 
 // 変数初期化の共通処理
-Node *handle_variable_initialization(Node *node, LVar *lvar, Type *type, int set_offset) {
+Node *handle_variable_initialization(Node *node, LVar *lvar, Type *type, int is_static_storage) {
   if (!consume("=")) {
-    if (set_offset)
-      lvar->offset = 0;
     return node;
   }
   Location *loc = consumed_loc;
-  if (set_offset && !peek("{") && token->kind != TK_STRING) {
-    lvar->offset = expect_signed_number();
+  if (is_static_storage && !peek("{") && token->kind != TK_STRING) {
+    lvar->init_value = expect_signed_number();
+    lvar->has_init_value = true;
     return node;
   }
   if (peek("{")) {
     if (type->ty == TY_STRUCT || type->ty == TY_UNION) {
-      node = handle_struct_initialization(node, lvar, type, set_offset);
+      node = handle_struct_initialization(node, lvar, type, is_static_storage);
     } else {
-      node = handle_array_initialization(node, lvar, type, set_offset);
+      node = handle_array_initialization(node, lvar, type, is_static_storage);
     }
   } else if (token->kind == TK_STRING) {
     node = handle_string_initialization(node, type, loc);
@@ -215,7 +214,6 @@ Node *function_definition(Token *tok, Type *type, int is_static, int is_inline) 
   }
   fn->name = tok->str;
   fn->len = tok->len;
-  fn->offset = 0;
   fn->is_static = is_static;
   fn->is_inline = is_inline;
   fn->type = type;
@@ -236,16 +234,7 @@ Node *function_definition(Token *tok, Type *type, int is_static, int is_inline) 
     Node *nd_lvar = new_node(ND_LVAR);
     node->args[i] = nd_lvar;
     LVar *lvar = new_lvar(tok_lvar, ptype, false, false);
-    int base = 0;
-    if (locals)
-      base = locals->offset;
     lvar->next = locals;
-    if (is_ptr_or_arr(ptype)) {
-      lvar->offset = base + 8;
-    } else {
-      lvar->offset = base + get_sizeof(ptype);
-    }
-    fn->offset = lvar->offset;
     nd_lvar->var = lvar;
     nd_lvar->type = ptype;
     locals = lvar;
@@ -281,24 +270,12 @@ Node *local_variable_declaration(Token *tok, Type *type, int is_static) {
   Node *node = new_node(ND_VARDEC);
   lvar = new_lvar(tok, type, is_static, false);
   LVar *static_lvar = NULL;
-  int base_offset = 0;
   if (is_static) {
     lvar->block = block_id;
     static_lvar = new_lvar(tok, type, true, false);
     static_lvar->block = lvar->block;
     static_lvar->next = statics;
     statics = static_lvar;
-  } else {
-    if (locals)
-      base_offset = locals->offset;
-    if (type->ty == TY_ARR && type->array_size == 0) {
-      lvar->offset = base_offset; // defer until initializer fixes array size
-    } else {
-      lvar->offset = base_offset + get_sizeof(type);
-      if (current_fn->offset < lvar->offset) {
-        current_fn->offset = lvar->offset;
-      }
-    }
   }
   node->var = lvar;
   node->type = type;
@@ -308,14 +285,12 @@ Node *local_variable_declaration(Token *tok, Type *type, int is_static) {
 
   // 要修正
   node = handle_variable_initialization(node, lvar, type, is_static);
-  if (!is_static && type->ty == TY_ARR && type->array_size != 0 && lvar->offset == base_offset) {
-    lvar->offset = base_offset + get_sizeof(type);
-    if (current_fn->offset < lvar->offset) {
-      current_fn->offset = lvar->offset;
-    }
+  if (static_lvar) {
+    static_lvar->init_value = lvar->init_value;
+    static_lvar->has_init_value = lvar->has_init_value;
+    static_lvar->init_array = lvar->init_array;
+    static_lvar->init_struct = lvar->init_struct;
   }
-  if (static_lvar)
-    static_lvar->offset = lvar->offset;
   node->endline = true;
   return node;
 }
@@ -405,7 +380,6 @@ Node *vardec_and_funcdef_stmt(int is_static, int is_extern, int is_inline) {
       fn->builtin_kind = BUILTIN_FN_NONE;
       fn->builtin_alias = NULL;
     }
-    fn->offset = 0;
     fn->is_static = is_static;
     fn->is_inline = is_inline;
     fn->type = type;
@@ -537,13 +511,13 @@ Object *struct_and_union_declaration(const int is_struct, const int is_union, co
           offset += single_size - (offset % single_size);
         if (max_size < single_size)
           max_size = single_size;
-        member_var->offset = offset;
+        member_var->member_offset = offset;
         offset += get_sizeof(base_type);
       } else {
         int usz = get_sizeof(base_type);
         if (max_size < usz)
           max_size = usz;
-        member_var->offset = 0;
+        member_var->member_offset = 0;
       }
       member_var->next = object->var;
       object->var = member_var;
@@ -593,7 +567,7 @@ Object *struct_and_union_declaration(const int is_struct, const int is_union, co
             if (offset % single_size != 0)
               offset += single_size - (offset % single_size);
             member_var->bit_offset = 0;
-            member_var->offset = offset;
+            member_var->member_offset = offset;
           } else {
             int storage_bits = single_size * 8;
             if (!active_bitfield_type || active_bitfield_type != type ||
@@ -605,7 +579,7 @@ Object *struct_and_union_declaration(const int is_struct, const int is_union, co
               active_bitfield_type = type;
               active_bit_offset_bits = 0;
             }
-            member_var->offset = offset;
+            member_var->member_offset = offset;
             member_var->bit_offset = active_bit_offset_bits;
             active_bit_offset_bits += bit_width;
             if (active_bit_offset_bits == storage_bits) {
@@ -615,7 +589,7 @@ Object *struct_and_union_declaration(const int is_struct, const int is_union, co
             }
           }
         } else {
-          member_var->offset = 0;
+          member_var->member_offset = 0;
           member_var->bit_offset = 0;
         }
         if (max_size < single_size)
@@ -631,10 +605,10 @@ Object *struct_and_union_declaration(const int is_struct, const int is_union, co
             offset += single_size - (offset % single_size);
           if (max_size < single_size)
             max_size = single_size;
-          member_var->offset = offset;
+          member_var->member_offset = offset;
           offset += get_sizeof(type);
         } else {
-          member_var->offset = 0;
+          member_var->member_offset = 0;
           if (max_size < single_size)
             max_size = single_size;
         }
@@ -717,10 +691,10 @@ Object *enum_declaration(const int should_record) {
     }
     LVar *member_var = new_lvar(member_tok, new_type(TY_INT), false, false);
     if (assigned) {
-      member_var->offset = assigned_val;
+      member_var->member_offset = assigned_val;
       value = assigned_val + 1;
     } else {
-      member_var->offset = value++;
+      member_var->member_offset = value++;
     }
     member_var->next = object->var;
     object->var = member_var;

--- a/src/parser/expr.c
+++ b/src/parser/expr.c
@@ -966,7 +966,7 @@ Node *access_member() {
       }
       tok = expect_ident("object reference");
       var = find_object_member(object, tok);
-      offset_node = new_num(var->offset);
+      offset_node = new_num(var->member_offset);
       ptr_node = new_node(ND_ADDR);
       ptr_node->lhs = node;
       ptr_node->type = new_type_ptr(node->type);
@@ -988,7 +988,7 @@ Node *access_member() {
       }
       tok = expect_ident("object reference");
       var = find_object_member(object, tok);
-      offset_node = new_num(var->offset);
+      offset_node = new_num(var->member_offset);
       ptr_node = new_binary(ND_ADD, node, offset_node);
       ptr_node->type = new_type_ptr(var->type);
       node = new_deref(ptr_node);
@@ -1096,7 +1096,7 @@ Node *primary() {
   // enumのメンバー
   LVar *member = find_enum_member(tok);
   if (member) {
-    node = new_num(member->offset);
+    node = new_num(member->member_offset);
     return node;
   }
 
@@ -1134,7 +1134,7 @@ int compile_time_number() {
     if (!member) {
       error_at(token->loc, "expected a compile time constant [in compile time number]");
     }
-    result = member->offset;
+    result = member->member_offset;
   } else {
     result = expect_signed_number();
   }

--- a/src/parser/parse.c
+++ b/src/parser/parse.c
@@ -387,7 +387,7 @@ static void parse_struct_or_union_initializer(StructLiteral *lit, Type *type, un
                  member_tok->str);
       }
       expect("=", "after member designator", "struct initializer");
-      parse_member_initializer(lit, member->type, base, buffer + member->offset);
+      parse_member_initializer(lit, member->type, base, buffer + member->member_offset);
       if (!consume(","))
         break;
       if (peek("}"))
@@ -410,7 +410,7 @@ static void parse_struct_or_union_initializer(StructLiteral *lit, Type *type, un
       first_decl = it;
       it = it->next;
     }
-    parse_member_initializer(lit, first_decl->type, base, buffer + first_decl->offset);
+    parse_member_initializer(lit, first_decl->type, base, buffer + first_decl->member_offset);
     if (consume(",")) {
       // Standard的には余剰要素はエラーとする
       error_at(token->loc, "excess elements in union initializer [in struct initializer]");
@@ -443,7 +443,7 @@ static void parse_struct_or_union_initializer(StructLiteral *lit, Type *type, un
       error_at(token->loc, "excess elements in struct initializer [in struct initializer]");
     }
     LVar *member = members[pos++];
-    parse_member_initializer(lit, member->type, base, buffer + member->offset);
+    parse_member_initializer(lit, member->type, base, buffer + member->member_offset);
     if (!consume(","))
       break;
     if (peek("}"))

--- a/src/parser/parser_internal.h
+++ b/src/parser/parser_internal.h
@@ -25,9 +25,9 @@ Node *vardec_and_funcdef_stmt(int is_static, int is_extern, int is_inline);
 Object *struct_and_union_declaration(int is_struct, int is_union, int should_record);
 Object *enum_declaration(int should_record);
 Node *typedef_stmt();
-Node *handle_array_initialization(Node *node, LVar *lvar, Type *type, int set_offset);
+Node *handle_array_initialization(Node *node, LVar *lvar, Type *type, int is_static_storage);
 Node *handle_scalar_initialization(Node *node, Type *type, Location *loc);
-Node *handle_variable_initialization(Node *node, LVar *lvar, Type *type, int set_offset);
+Node *handle_variable_initialization(Node *node, LVar *lvar, Type *type, int is_static_storage);
 
 Node *block_stmt();
 Node *goto_stmt();

--- a/src/types/symbol.c
+++ b/src/types/symbol.c
@@ -71,6 +71,9 @@ LVar *new_lvar(Token *tok, Type *type, int is_static, int is_extern) {
   lvar->is_extern = is_extern;
   lvar->is_static = is_static;
   lvar->type = type;
+  lvar->member_offset = 0;
+  lvar->init_value = 0;
+  lvar->has_init_value = false;
   lvar->init_array = NULL;
   lvar->init_struct = NULL;
   lvar->is_bitfield = 0;

--- a/tests/unittest.c
+++ b/tests/unittest.c
@@ -274,6 +274,7 @@ int main() {
   CHECK(regress_postinc_test2(), 54);
   CHECK(regress_postinc_test3(), 561);
   CHECK(regress_postinc_test4(), 255);
+  CHECK(regress_local_slot_test1(20), 41);
 
   // bool / _Bool tests
   CHECK(bool_test1(), 2);

--- a/tests/unittests/regressions_postinc.c
+++ b/tests/unittests/regressions_postinc.c
@@ -27,3 +27,12 @@ int regress_postinc_test4() {
   int r = u++;
   return r + u; // 255 + 0 = 255 (well-defined wrap for unsigned char)
 }
+
+int regress_local_slot_test1(int x) {
+  int a[3];
+  long unused = x + 3;
+  int b[3];
+  a[0] = x;
+  b[0] = x + 1;
+  return a[0] + b[0];
+}


### PR DESCRIPTION
  - LVar::offset、Function::offset を削除
  - メンバー位置は member_offset に分離
  - static/global 初期値は init_value と has_init_value に分離
  - ローカル変数は MIR スロットで管理し、最適化後に連続した offset を割り当て

close #85 